### PR TITLE
Restore usage section intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const wcc = require("world-countries-capitals");
 
 ## Usage
 
-This section contains nt to _contribute_ to open source? Try solving our issues [here](https://github.com/bhatvikrant/world-countries-capitals/issues)\_
+This section contains information about various functions that are currently supported.
 
 - `getAllCountryDetails()` <br>
   This method returns an **array of objects** containing all countries, each containing **country**, **capital**, **currency**, **native_language**, **famous for**, **phone_code**, and its **flag**.


### PR DESCRIPTION
I noticed this scrambled message on row 37 in README.md: ```This section contains nt to _contribute_ to open source? Try solving our issues [here](https://github.com/bhatvikrant/world-countries-capitals/issues)\_```

It seems that the change comes from https://github.com/bhatvikrant/world-countries-capitals/commit/cd893665c7fa6d8c29431efee1078da7c5354a05#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37. 

My commit restores the text to what was there previously.
